### PR TITLE
fix: 修复assertion

### DIFF
--- a/loadtest/src/bin/grpc_naming_register.rs
+++ b/loadtest/src/bin/grpc_naming_register.rs
@@ -14,7 +14,7 @@ fn get_service_ip_list(counts: u64) -> Vec<String> {
     let (icount, jcount) = if counts <= 100 {
         (1, counts)
     } else {
-        assert!(counts > 10000, "不支持超过1万个ip");
+        assert!(counts <= 10000, "不支持超过1万个ip");
         (counts % 100 + 1, 100)
     };
     let mut sum = 0;

--- a/src/common/sled_utils.rs
+++ b/src/common/sled_utils.rs
@@ -79,7 +79,7 @@ pub struct TableSequence {
 impl TableSequence {
     pub fn new(db: Arc<sled::Db>, table_seq_key: String, batch_size: u64) -> Self {
         let last_id = load_table_last_id(&db, &table_seq_key).unwrap_or_default();
-        assert!(batch_size > 0, "batch size is greater than 0");
+        assert!(batch_size > 0, "batch size must be greater than 0");
         Self {
             cache_size: 0,
             last_id,


### PR DESCRIPTION
根据代码逻辑，`assert!(counts > 10000, "不支持超过1万个ip");`这里应该是处理不超过1万个ip的情况，所以应该被修复为`assert!(counts <= 10000, "不支持超过1万个ip");`
```rust
fn get_service_ip_list(counts: u64) -> Vec<String> {
    let (icount, jcount) = if counts <= 100 {
        (1, counts)
    } else {
        assert!(counts > 10000, "不支持超过1万个ip");
        (counts % 100 + 1, 100)
    };
    let mut sum = 0;
    let mut rlist = vec![];
    for i in 100..(100 + icount) {
        for j in 100..(100 + jcount) {
            sum += 1;
            if sum > counts {
                return rlist;
            }
            let ip = format!("192.168.{}.{}", &i, &j);
            rlist.push(ip);
        }
    }
    rlist
}
```