### PR TITLE
feat: 添加OAuth2.0认证支持

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ ldap3 = { version="0.11", default-features = false, features = ["tls-rustls"] }
 reqwest = {version="0.11", default-features = false, features = ["stream", "rustls-tls", "json"]}
 rand = "0.8"
 serde_yml = "0.0.12"
+oauth2 = "4.4"
 
 [target.'cfg(any(target_os = "linux", target_os = "macos", target_os="windows"))'.dependencies]
 fs2 = "0.4.3"

--- a/README.md
+++ b/README.md
@@ -207,6 +207,18 @@ helm install r-nacos rnacos/rnacos
 |RNACOS_LDAP_USER_ADMIN_GROUP|LDAP管理员角色包含的用户组(多个用逗号分隔，用户只要包含一个就是管理员)|空集合|admin_group1,admin_group2|0.6.19|
 |RNACOS_LDAP_USER_DEFAULT_ROLE|LDAP用户默认角色,支持的值有：访客:VISITOR,开发者:DEVELOPER,管理员:ADMIN|VISITOR|DEVELOPER|0.6.19|
 |RNACOS_MCP_HTTP_TIMEOUT_SECOND|MCP服务HTTP请求超时时间，单位为秒|30|60|0.7.3|
+|RNACOS_OAUTH2_ENABLE|是否启用OAuth2.0认证|false|true|x|
+|RNACOS_OAUTH2_CLIENT_ID|OAuth2.0客户端ID|空字符串|your_client_id|x|
+|RNACOS_OAUTH2_CLIENT_SECRET|OAuth2.0客户端密钥|空字符串|your_client_secret|x|
+|RNACOS_OAUTH2_REDIRECT_URI|OAuth2.0回调完整URI(只修改域名部分即可)|空字符串|http://localhost:10848/rnacos/p/login|x|
+|RNACOS_OAUTH2_AUTHORIZATION_URL|OAuth2.0授权端点完整URL|空字符串|https://oauth.example.com/oauth/authorize|x|
+|RNACOS_OAUTH2_TOKEN_URL|OAuth2.0 Token端点完整URL|空字符串|https://oauth.example.com/oauth/token|x|
+|RNACOS_OAUTH2_USERINFO_URL|OAuth2.0用户信息端点完整URL|空字符串|https://oauth.example.com/oauth/userinfo|x|
+|RNACOS_OAUTH2_SCOPES|OAuth2.0请求的权限范围|openid profile|openid profile email|x|
+|RNACOS_OAUTH2_USERNAME_CLAIM_NAME|OAuth2.0用户名claim字段名|username|username|x|
+|RNACOS_OAUTH2_NICKNAME_CLAIM_NAME|OAuth2.0昵称claim字段名|name|name|x|
+|RNACOS_OAUTH2_USER_DEFAULT_ROLE|OAuth2.0用户默认角色,支持的值有：访客:VISITOR,开发者:DEVELOPER,管理员:ADMIN|DEVELOPER|VISITOR|x|
+|RNACOS_OAUTH2_BUTTON|OAuth2.0登录按钮显示文本|OAuth2.0 登录|OAuth2.0 登录|x|
 
 启动配置方式可以参考： [运行参数说明](https://r-nacos.github.io/docs/notes/env_config/)
 
@@ -437,6 +449,8 @@ nacos_rust_client = "0.3.0"
 1. 支持管理用户列表
 2. 支持用户角色权限管理
 3. 支持用户密码重置
+4. 支持LDAP认证登录
+5. 支持OAuth2.0认证登录
 
 命名空间：
 

--- a/src/common/appdata.rs
+++ b/src/common/appdata.rs
@@ -10,6 +10,7 @@ use crate::namespace::NamespaceActor;
 use crate::naming::cluster::node_manage::{InnerNodeManage, NodeManage};
 use crate::naming::cluster::route::NamingRoute;
 use crate::naming::core::NamingActor;
+use crate::oauth2::core::OAuth2Manager;
 use crate::raft::cache::route::CacheRoute;
 use crate::raft::cache::CacheManager;
 use crate::raft::cluster::route::{ConfigRoute, RaftRequestRoute};
@@ -54,6 +55,7 @@ pub struct AppShareData {
     pub transfer_import_manager: Addr<TransferImportManager>,
     pub health_manager: Addr<HealthManager>,
     pub ldap_manager: Addr<LdapManager>,
+    pub oauth2_manager: Addr<OAuth2Manager>,
     pub sequence_db_manager: Addr<SequenceDbManager>,
     pub sequence_manager: Addr<SequenceManager>,
     pub mcp_manager: Addr<McpManager>,

--- a/src/console/api.rs
+++ b/src/console/api.rs
@@ -224,6 +224,8 @@ pub fn console_api_config_v2(config: &mut web::ServiceConfig) {
                 web::resource("/login/captcha").route(web::get().to(v2::login_api::gen_captcha)),
             )
             .service(web::resource("/login/logout").route(web::post().to(v2::login_api::logout)))
+            .service(web::resource("/login/config").route(web::get().to(login_api::get_login_config)))
+            .service(web::resource("/login/oauth2/login").route(web::post().to(v2::login_api::oauth2_callback)))
             .service(web::resource("/user/info").route(web::get().to(v2::user_api::get_user_info)))
             .service(
                 web::resource("/user/list").route(web::get().to(v2::user_api::get_user_page_list)),

--- a/src/console/middle/login_middle.rs
+++ b/src/console/middle/login_middle.rs
@@ -25,6 +25,7 @@ lazy_static::lazy_static! {
         "/rnacos/p/login", "/rnacos/404",
         "/rnacos/api/console/login/login", "/rnacos/api/console/login/captcha",
         "/rnacos/api/console/v2/login/login", "/rnacos/api/console/v2/login/captcha",
+        "/rnacos/api/console/v2/login/config", "/rnacos/api/console/v2/login/oauth2/login",
     ];
     pub static ref STATIC_FILE_PATH: Regex= Regex::new(r"(?i).*\.(js|css|png|jpg|jpeg|bmp|svg)").unwrap();
     pub static ref API_PATH: Regex = Regex::new(r"(?i)/(api|nacos)/.*").unwrap();

--- a/src/console/model/login_model.rs
+++ b/src/console/model/login_model.rs
@@ -14,3 +14,11 @@ pub struct LoginParam {
 pub struct LoginToken {
     pub token: String,
 }
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LoginConfig {
+    pub oauth2_enable: bool,
+    pub oauth2_button: Option<String>,
+    pub oauth2_authorize_url: Option<String>,
+}

--- a/src/console/v2/login_api.rs
+++ b/src/console/v2/login_api.rs
@@ -1,1 +1,1 @@
-pub use crate::console::login_api::{gen_captcha, login, logout};
+pub use crate::console::login_api::{gen_captcha, get_login_config, login, logout, oauth2_callback};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ pub mod transfer;
 
 pub mod ldap;
 pub mod mcp;
+pub mod oauth2;
 pub mod sequence;
 
 pub use inner_mem_cache::TimeoutSet;

--- a/src/oauth2/core.rs
+++ b/src/oauth2/core.rs
@@ -1,0 +1,89 @@
+use crate::oauth2::model::actor_model::{OAuth2MsgReq, OAuth2MsgResult};
+use crate::oauth2::model::OAuth2Config;
+use crate::oauth2::oauth2_msg_actor::OAuth2MsgActor;
+use crate::user::UserManager;
+use actix::prelude::*;
+use bean_factory::{bean, BeanFactory, FactoryData, Inject};
+use std::sync::Arc;
+
+#[bean(inject)]
+pub struct OAuth2Manager {
+    oauth2_config: Arc<OAuth2Config>,
+    oauth2_msg_actor: Option<Addr<OAuth2MsgActor>>,
+    enable_oauth2: bool,
+    user_manager_addr: Option<Addr<UserManager>>,
+}
+
+impl OAuth2Manager {
+    pub fn new(oauth2_config: Arc<OAuth2Config>, enable_oauth2: bool) -> Self {
+        Self {
+            oauth2_config,
+            oauth2_msg_actor: None,
+            enable_oauth2,
+            user_manager_addr: None,
+        }
+    }
+
+    pub fn init(&mut self, _ctx: &mut Context<Self>) {
+        if !self.enable_oauth2 {
+            return;
+        }
+        let oauth2_config = self.oauth2_config.clone();
+        let user_manager_addr = self.user_manager_addr.clone();
+        match OAuth2MsgActor::new(oauth2_config, user_manager_addr) {
+            Ok(actor) => {
+                let oauth2_msg_actor = actor.start();
+                self.oauth2_msg_actor = Some(oauth2_msg_actor);
+            }
+            Err(err) => {
+                log::error!("init oauth2 error:{}", err);
+            }
+        }
+    }
+
+    async fn handle_req(
+        req: OAuth2MsgReq,
+        oauth2_msg_addr: Option<Addr<OAuth2MsgActor>>,
+    ) -> anyhow::Result<OAuth2MsgResult> {
+        let oauth2_msg_addr = if let Some(v) = oauth2_msg_addr {
+            v
+        } else {
+            return Err(anyhow::anyhow!("oauth2_msg_addr is None"));
+        };
+        oauth2_msg_addr.send(req).await?
+    }
+}
+
+impl Actor for OAuth2Manager {
+    type Context = Context<Self>;
+    fn started(&mut self, _ctx: &mut Self::Context) {
+        log::info!("OAuth2Manager started");
+    }
+}
+
+impl Inject for OAuth2Manager {
+    type Context = Context<Self>;
+
+    fn inject(
+        &mut self,
+        factory_data: FactoryData,
+        _factory: BeanFactory,
+        ctx: &mut Self::Context,
+    ) {
+        self.user_manager_addr = factory_data.get_actor();
+        self.init(ctx);
+    }
+}
+
+impl Handler<OAuth2MsgReq> for OAuth2Manager {
+    type Result = ResponseActFuture<Self, anyhow::Result<OAuth2MsgResult>>;
+
+    fn handle(&mut self, msg: OAuth2MsgReq, _ctx: &mut Self::Context) -> Self::Result {
+        let msg_addr = self.oauth2_msg_actor.clone();
+        let fut = Self::handle_req(msg, msg_addr)
+            .into_actor(self)
+            .map(|result, _act, _ctx| result);
+        Box::pin(fut)
+    }
+}
+

--- a/src/oauth2/mod.rs
+++ b/src/oauth2/mod.rs
@@ -1,0 +1,4 @@
+pub mod core;
+pub mod model;
+mod oauth2_msg_actor;
+

--- a/src/oauth2/model/actor_model.rs
+++ b/src/oauth2/model/actor_model.rs
@@ -1,0 +1,17 @@
+use crate::oauth2::model::{OAuth2UserMeta, OAuth2UserParam};
+use actix::prelude::*;
+
+#[derive(Clone, Debug, Message)]
+#[rtype(result = "anyhow::Result<OAuth2MsgResult>")]
+pub enum OAuth2MsgReq {
+    Authenticate(OAuth2UserParam),
+    GetAuthorizeUrl,
+}
+
+#[derive(Clone, Debug)]
+pub enum OAuth2MsgResult {
+    None,
+    UserMeta(OAuth2UserMeta),
+    AuthorizeUrl(String),
+}
+

--- a/src/oauth2/model/mod.rs
+++ b/src/oauth2/model/mod.rs
@@ -1,0 +1,47 @@
+use crate::common::model::privilege::PrivilegeGroup;
+use std::sync::Arc;
+
+pub mod actor_model;
+
+#[derive(Clone, Debug, Default)]
+pub struct OAuth2Config {
+    pub oauth2_server_url: Arc<String>,
+    pub oauth2_client_id: Arc<String>,
+    pub oauth2_client_secret: Arc<String>,
+    pub oauth2_authorization_url: Arc<String>,
+    pub oauth2_token_url: Arc<String>,
+    pub oauth2_userinfo_url: Arc<String>,
+    pub oauth2_redirect_uri: Arc<String>,
+    pub oauth2_scopes: Arc<String>,
+    pub oauth2_username_claim_name: Arc<String>,
+    pub oauth2_nickname_claim_name: Arc<String>,
+    pub oauth2_user_default_role: Arc<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct OAuth2UserParam {
+    pub code: String,
+    pub state: Option<String>,
+}
+
+#[derive(Clone, Debug)]
+pub struct OAuth2UserMeta {
+    pub user_name: String,
+    pub role: Arc<String>,
+    pub namespace_privilege: Option<PrivilegeGroup<Arc<String>>>,
+}
+
+impl OAuth2UserMeta {
+    pub fn new(
+        user_name: String,
+        role: Arc<String>,
+        namespace_privilege: Option<PrivilegeGroup<Arc<String>>>,
+    ) -> Self {
+        Self {
+            user_name,
+            role,
+            namespace_privilege,
+        }
+    }
+}
+

--- a/src/oauth2/oauth2_msg_actor.rs
+++ b/src/oauth2/oauth2_msg_actor.rs
@@ -1,0 +1,206 @@
+use crate::common::get_app_version;
+use crate::oauth2::model::actor_model::{OAuth2MsgReq, OAuth2MsgResult};
+use crate::oauth2::model::OAuth2Config;
+use crate::user::model::{UserDto, UserSourceType};
+use crate::user::{UserManager, UserManagerReq, UserManagerResult};
+use actix::prelude::*;
+use oauth2::{
+    basic::BasicClient, reqwest::async_http_client, AuthorizationCode, ClientId, ClientSecret,
+    RedirectUrl, Scope, TokenResponse,
+};
+use reqwest::Client;
+use serde_json::Value;
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct OAuth2MsgActor {
+    oauth2_config: Arc<OAuth2Config>,
+    user_manager_addr: Option<Addr<UserManager>>,
+    http_client: Client,
+    oauth2_client: BasicClient,
+    scopes: Vec<Scope>,
+}
+
+impl OAuth2MsgActor {
+    pub(crate) fn new(
+        oauth2_config: Arc<OAuth2Config>,
+        user_manager_addr: Option<Addr<UserManager>>,
+    ) -> anyhow::Result<Self> {
+        let client_id = ClientId::new(oauth2_config.oauth2_client_id.as_ref().clone());
+        let client_secret = ClientSecret::new(
+            oauth2_config.oauth2_client_secret.as_ref().clone(),
+        );
+        // Use full URLs directly
+        let auth_url = oauth2_config.oauth2_authorization_url.as_ref().clone();
+        let token_url = oauth2_config.oauth2_token_url.as_ref().clone();
+
+        let redirect_url = RedirectUrl::new(
+            oauth2_config.oauth2_redirect_uri.as_ref().clone(),
+        )?;
+
+        let oauth2_client = BasicClient::new(
+            client_id,
+            Some(client_secret),
+            oauth2::AuthUrl::new(auth_url)?,
+            Some(oauth2::TokenUrl::new(token_url)?),
+        )
+        .set_redirect_uri(redirect_url);
+
+        // Parse scopes
+        let scopes: Vec<Scope> = oauth2_config
+            .oauth2_scopes
+            .split_whitespace()
+            .map(|s| Scope::new(s.to_string()))
+            .collect();
+
+        Ok(Self {
+            oauth2_config,
+            user_manager_addr,
+            http_client: Client::builder()
+                .danger_accept_invalid_certs(true)
+                .build()
+                .unwrap_or_else(|_| Client::new()),
+            oauth2_client,
+            scopes,
+        })
+    }
+
+    async fn handle_req(
+        &self,
+        msg: OAuth2MsgReq,
+    ) -> anyhow::Result<OAuth2MsgResult> {
+        match msg {
+            OAuth2MsgReq::GetAuthorizeUrl => {
+                let (auth_url, _csrf_state) = self.oauth2_client
+                    .authorize_url(oauth2::CsrfToken::new_random)
+                    .add_scopes(self.scopes.clone())
+                    .url();
+
+                Ok(OAuth2MsgResult::AuthorizeUrl(auth_url.to_string()))
+            }
+            OAuth2MsgReq::Authenticate(param) => {
+
+                // Exchange authorization code for token
+                let token = self.oauth2_client
+                    .exchange_code(AuthorizationCode::new(param.code.clone()))
+                    .request_async(async_http_client)
+                    .await
+                    .map_err(|e| {
+                        log::error!("OAuth2 token exchange failed: {}", e);
+                        anyhow::anyhow!("OAuth2 token exchange failed: {}", e)
+                    })?;
+
+                let access_token = token.access_token().secret();
+
+                // Get user info - use full URL directly
+                let userinfo_url = self.oauth2_config.oauth2_userinfo_url.as_ref().clone();
+
+                // Build request with bearer token
+                // Use bearer_auth which sets: Authorization: Bearer <token>
+                // GitHub and some OAuth2 providers require User-Agent header
+                let user_agent = format!("r-nacos/{}", get_app_version());
+                let request = self.http_client
+                    .get(&userinfo_url)
+                    .bearer_auth(access_token.clone())
+                    .header("Accept", "application/json")
+                    .header("User-Agent", user_agent);
+                
+                let userinfo_response = request.send().await?;
+
+                // Check response status
+                let status = userinfo_response.status();
+                if !status.is_success() {
+                    let error_text = userinfo_response.text().await.unwrap_or_default();
+                    log::error!("OAuth2 userinfo request failed: status={}, url={}, body={}", status, userinfo_url, error_text);
+                    return Err(anyhow::anyhow!("OAuth2 userinfo request failed: status={}, body={}", status, error_text));
+                }
+
+                // Parse JSON directly
+                let userinfo: Value = userinfo_response.json().await.map_err(|e| {
+                    log::error!("OAuth2 userinfo JSON parse error: {}", e);
+                    anyhow::anyhow!("Failed to parse OAuth2 userinfo response: {}", e)
+                })?;
+
+                // Log the complete userinfo response for debugging
+                log::info!("OAuth2 userinfo response: {}", serde_json::to_string_pretty(&userinfo).unwrap_or_else(|_| "Failed to serialize".to_string()));
+
+                // Extract username from claims
+                let username_claim_name = self.oauth2_config.oauth2_username_claim_name.as_ref();
+                let user_name = userinfo
+                    .get(username_claim_name)
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| {
+                        log::error!("OAuth2 username claim '{}' not found", username_claim_name);
+                        anyhow::anyhow!("username claim '{}' not found", username_claim_name)
+                    })?
+                    .to_string();
+
+                // Extract nickname from claims
+                let nickname_claim_name = self.oauth2_config.oauth2_nickname_claim_name.as_ref();
+                let nickname = userinfo
+                    .get(nickname_claim_name)
+                    .and_then(|v| v.as_str())
+                    .map(|s| s.to_string())
+                    .ok_or_else(|| {
+                        log::error!("OAuth2 nickname claim '{}' not found", nickname_claim_name);
+                        anyhow::anyhow!("nickname claim '{}' not found", nickname_claim_name)
+                    })?;
+
+                // Use configured default role
+                let role = self.oauth2_config.oauth2_user_default_role.clone();
+                let mut namespace_privilege = None;
+
+                // Initialize user
+                if let Some(user_manager_addr) = &self.user_manager_addr {
+                    let user = UserDto {
+                        username: Arc::new(user_name.clone()),
+                        nickname: Some(nickname),
+                        source: Some(UserSourceType::Inner.to_str().to_owned()),
+                        roles: Some(vec![role.clone()]),
+                        ..Default::default()
+                    };
+                    if let Ok(Ok(UserManagerResult::QueryUser(Some(user_dto)))) =
+                        user_manager_addr
+                            .send(UserManagerReq::InitUser {
+                                user,
+                                namespace_privilege_param: None,
+                            })
+                            .await
+                    {
+                        namespace_privilege = user_dto.namespace_privilege;
+                    }
+                }
+
+                let meta = crate::oauth2::model::OAuth2UserMeta::new(
+                    user_name,
+                    role,
+                    namespace_privilege,
+                );
+                Ok(OAuth2MsgResult::UserMeta(meta))
+            }
+        }
+    }
+}
+
+impl Actor for OAuth2MsgActor {
+    type Context = Context<Self>;
+
+    fn started(&mut self, _ctx: &mut Self::Context) {
+        log::info!("OAuth2MsgActor started");
+    }
+}
+
+impl Handler<OAuth2MsgReq> for OAuth2MsgActor {
+    type Result = ResponseActFuture<Self, anyhow::Result<OAuth2MsgResult>>;
+
+    fn handle(&mut self, msg: OAuth2MsgReq, _ctx: &mut Self::Context) -> Self::Result {
+        let actor = self.clone();
+        let fut = async move {
+            actor.handle_req(msg).await
+        }
+        .into_actor(self)
+        .map(|result, _act, _ctx| result);
+        Box::pin(fut)
+    }
+}
+

--- a/src/starter.rs
+++ b/src/starter.rs
@@ -5,6 +5,7 @@ use crate::grpc::handler::RAFT_ROUTE_REQUEST;
 use crate::health::core::HealthManager;
 use crate::ldap::core::LdapManager;
 use crate::mcp::core::McpManager;
+use crate::oauth2::core::OAuth2Manager;
 use crate::mcp::sse_manage::SseStreamManager;
 use crate::metrics::core::MetricsManager;
 use crate::namespace::NamespaceActor;
@@ -217,6 +218,9 @@ pub async fn config_factory(sys_config: Arc<AppSysConfig>) -> anyhow::Result<Fac
     let ldap_manager =
         LdapManager::new(sys_config.get_ldap_config(), sys_config.ldap_enable).start();
     factory.register(BeanDefinition::actor_with_inject_from_obj(ldap_manager));
+    let oauth2_manager =
+        OAuth2Manager::new(sys_config.get_oauth2_config(), sys_config.oauth2_enable).start();
+    factory.register(BeanDefinition::actor_with_inject_from_obj(oauth2_manager));
     let sse_manager = SseStreamManager::new().start();
     factory.register(BeanDefinition::actor_with_inject_from_obj(sse_manager));
     Ok(factory.init().await)
@@ -264,6 +268,7 @@ pub fn build_share_data(factory_data: FactoryData) -> anyhow::Result<Arc<AppShar
         transfer_import_manager: factory_data.get_actor().unwrap(),
         health_manager: factory_data.get_actor().unwrap(),
         ldap_manager: factory_data.get_actor().unwrap(),
+        oauth2_manager: factory_data.get_actor().unwrap(),
         sequence_manager: factory_data.get_actor().unwrap(),
         sequence_db_manager: factory_data.get_actor().unwrap(),
         mcp_manager: factory_data.get_actor().unwrap(),

--- a/src/user/permission.rs
+++ b/src/user/permission.rs
@@ -147,6 +147,8 @@ lazy_static::lazy_static! {
         R::Path("/rnacos/api/console/v2/login/login",HTTP_METHOD_ALL),
         R::Path("/rnacos/api/console/v2/login/captcha",HTTP_METHOD_ALL),
         R::Path("/rnacos/api/console/v2/login/logout",HTTP_METHOD_ALL),
+        R::Path("/rnacos/api/console/v2/login/config",HTTP_METHOD_ALL),
+        R::Path("/rnacos/api/console/v2/login/oauth2/login",HTTP_METHOD_ALL),
         R::Path("/rnacos/api/console/v2/user/info",HTTP_METHOD_GET),
         R::Path("/rnacos/api/console/v2/user/web_resources",HTTP_METHOD_GET),
         R::Path("/rnacos/api/console/v2/user/reset_password",HTTP_METHOD_ALL),


### PR DESCRIPTION
### 改动预览
- 在Cargo.toml中添加oauth2依赖
- 更新README.md，增加OAuth2.0相关环境变量说明
- 新增oauth2模块及相关配置
- 在starter中注册OAuth2Manager
- 更新登录API以支持OAuth2.0登录
- 添加OAuth2.0回调处理逻辑
- 更新权限管理以支持OAuth2.0认证

### 对应的前端改动
https://github.com/r-nacos/rnacos-console-web/pull/43

### 功能预览
![871f1ba9-b931-4667-b746-c6538620395e](https://github.com/user-attachments/assets/84ac34d6-d540-4a82-adf3-f1dca73dcc29)

### 注意的问题
readme 文件中环境变量的解释版本号是 x, 暂时不知道哪个版本合并, 所以就没写

### OAuth 的配置示例
```
RNACOS_CONSOLE_ENABLE_CAPTCHA=true
RNACOS_OAUTH2_ENABLE=true
RNACOS_OAUTH2_CLIENT_ID=Ov23liRx4CDcdTyBLU7z
RNACOS_OAUTH2_CLIENT_SECRET=5654412e2d29380328f0cd904aea8d8f59a2db51
RNACOS_OAUTH2_AUTHORIZATION_URL=https://github.com/login/oauth/authorize
RNACOS_OAUTH2_TOKEN_URL=https://github.com/login/oauth/access_token
RNACOS_OAUTH2_USERINFO_URL=https://api.github.com/user
RNACOS_OAUTH2_REDIRECT_URI=http://localhost:5173/rnacos/p/login
RNACOS_OAUTH2_BUTTON="Github登录"
RNACOS_OAUTH2_USERNAME_CLAIM_NAME=name
RNACOS_OAUTH2_NICKNAME_CLAIM_NAME=name
RNACOS_OAUTH2_USER_DEFAULT_ROLE=DEVELOPER
```