### PR TITLE
fix: MCP服务添加工具一键刷新功能 (issue #279)

### DIFF
--- a/src/console/api.rs
+++ b/src/console/api.rs
@@ -412,6 +412,10 @@ pub fn console_api_config_v2(config: &mut web::ServiceConfig) {
             .service(
                 web::resource("/mcp/server/import")
                     .route(web::post().to(v2::mcp_server_api::import_mcp_servers)),
+            )
+            .service(
+                web::resource("/mcp/server/update_tools")
+                    .route(web::post().to(v2::mcp_server_api::update_tools)),
             ),
     );
 }

--- a/src/console/v2/mcp_server_api.rs
+++ b/src/console/v2/mcp_server_api.rs
@@ -842,3 +842,30 @@ async fn update_mcp_server_for_import(
         )),
     }
 }
+
+/// 刷新所有服务引用的工具到最新版本
+pub async fn update_tools(
+    _req: HttpRequest,
+    appdata: web::Data<Arc<AppShareData>>,
+) -> impl Responder {
+    // 发送刷新请求到MCP Manager
+    let cmd = McpManagerReq::RefreshAllServerTools;
+    match appdata.mcp_manager.send(cmd).await {
+        Ok(res) => match res {
+            Ok(McpManagerResult::RefreshResult(updated_count, skipped_count)) => {
+                let message = format!(
+                    "工具刷新完成: 更新了 {} 个服务，跳过了 {} 个服务",
+                    updated_count, skipped_count
+                );
+                log::info!("{}", message);
+                HttpResponse::Ok().json(ApiResult::success(Some(message)))
+            }
+            Ok(_) => handle_unexpected_response_error("MCP Manager refresh tools"),
+            Err(err) => handle_mcp_manager_error(err, "refresh tools"),
+        },
+        Err(err) => handle_system_error(
+            format!("Unable to connect to MCP Manager: {}", err),
+            "Failed to send refresh tools request to MCP Manager",
+        ),
+    }
+}

--- a/src/mcp/core.rs
+++ b/src/mcp/core.rs
@@ -255,6 +255,65 @@ impl McpManager {
         Ok(())
     }
 
+    /// 刷新所有服务引用的工具到最新版本
+    /// 返回: (更新的服务数量, 跳过的服务数量)
+    fn refresh_all_server_tools(&mut self) -> (usize, usize) {
+        let mut updated_count = 0;
+        let mut skipped_count = 0;
+
+        for server in self.server_map.values_mut() {
+            let mut server_updated = false;
+
+            // 检查并刷新 current_value
+            if self.refresh_server_value_tools(&mut server.as_ref().to_owned().current_value) {
+                server_updated = true;
+            }
+
+            // 检查并刷新 release_value
+            if self.refresh_server_value_tools(&mut server.as_ref().to_owned().release_value) {
+                server_updated = true;
+            }
+
+            if server_updated {
+                // 更新 server_map 中的服务
+                let server_clone = server.as_ref().clone();
+                self.server_map.insert(server_clone.id, Arc::new(server_clone));
+                updated_count += 1;
+            } else {
+                skipped_count += 1;
+            }
+        }
+
+        // 重建引用计数
+        self.init_tool_spec_version_ref_map();
+
+        (updated_count, skipped_count)
+    }
+
+    /// 刷新单个服务值中的工具引用到最新版本
+    /// 返回: 是否进行了更新
+    fn refresh_server_value_tools(&self, server_value: &mut McpServerValue) -> bool {
+        let mut updated = false;
+
+        for tool in &mut server_value.tools {
+            if let Some(tool_spec) = self.tool_spec_map.get(&tool.tool_key) {
+                let latest_version = tool_spec.current_version;
+                if tool.tool_version != latest_version {
+                    log::info!(
+                        "Updating tool {} from version {} to latest version {}",
+                        tool.tool_key.tool_name.as_str(),
+                        tool.tool_version,
+                        latest_version
+                    );
+                    tool.tool_version = latest_version;
+                    updated = true;
+                }
+            }
+        }
+
+        updated
+    }
+
     fn set_tool_spec(&mut self, tool_spec: Arc<ToolSpec>) {
         self.tool_spec_map.insert(tool_spec.key.clone(), tool_spec);
     }
@@ -546,6 +605,15 @@ impl Handler<McpManagerReq> for McpManager {
             McpManagerReq::QueryToolSpec(query_param) => {
                 let (size, list) = self.query_tool_specs(&query_param);
                 Ok(McpManagerResult::ToolSpecPageInfo(size, list))
+            }
+            McpManagerReq::RefreshAllServerTools => {
+                let (updated_count, skipped_count) = self.refresh_all_server_tools();
+                log::info!(
+                    "RefreshAllServerTools: updated={}, skipped={}",
+                    updated_count,
+                    skipped_count
+                );
+                Ok(McpManagerResult::RefreshResult(updated_count, skipped_count))
             }
         }
     }

--- a/src/mcp/model/actor_model.rs
+++ b/src/mcp/model/actor_model.rs
@@ -16,6 +16,8 @@ pub enum McpManagerReq {
     QueryServerHistory(u64, usize, usize, Option<i64>, Option<i64>),
     GetToolSpec(ToolKey),
     QueryToolSpec(McpToolSpecQueryParam),
+    /// 刷新所有服务引用的工具到最新版本
+    RefreshAllServerTools,
 }
 
 /// MCP 查询结果
@@ -26,6 +28,8 @@ pub enum McpManagerResult {
     ServerHistoryPageInfo(usize, Vec<McpServerValue>),
     ToolSpecInfo(Option<Arc<ToolSpec>>),
     ToolSpecPageInfo(usize, Vec<ToolSpecDto>),
+    /// 刷新工具结果: (更新的服务数量, 跳过的不需要更新的服务数量)
+    RefreshResult(usize, usize),
     None,
 }
 


### PR DESCRIPTION
## 修复 issue #279

### 问题描述
MCP工具定义修改后，服务引用的工具不会跟着更新。

### 解决方案
在 MCP 编辑页支持一键更新所有工具到最新版本。

### 实现内容

1. **在 McpManager 中添加刷新逻辑** (`src/mcp/core.rs`):
   - 添加 `refresh_all_server_tools` 方法，遍历所有服务
   - 添加 `refresh_server_value_tools` 方法，检查并更新单个服务值中的工具版本
   - 在 `Handler<McpManagerReq>` 中处理 `RefreshAllServerTools` 请求

2. **添加新的 API 接口** (`src/console/v2/mcp_server_api.rs`):
   - 添加 `update_tools` 函数
   - 路由: `POST /api/v2/mcp/server/update_tools`
   - 返回更新和跳过的服务数量

3. **注册路由** (`src/console/api.rs`):
   - 添加 `/mcp/server/update_tools` 路由

### 使用方式
调用 `POST /api/v2/mcp/server/update_tools` 接口，系统会：
1. 遍历所有 MCP 服务
2. 检查每个服务的 current_value 和 release_value 中的工具版本
3. 将不是最新版本的工具引用更新为最新版本
4. 重建工具引用计数
5. 返回更新和跳过的服务数量
